### PR TITLE
use correct config file parameter in el6 init script

### DIFF
--- a/el6/mesos-dns.conf
+++ b/el6/mesos-dns.conf
@@ -6,4 +6,4 @@ stop on runlevel [!2345]
 respawn
 respawn limit 10 5
 
-exec /usr/bin/mesos-dns -conf /etc/mesos-dns/config.json
+exec /usr/bin/mesos-dns -config /etc/mesos-dns/config.json


### PR DESCRIPTION
The configuration file parameter is "config" and not "conf".
