### PR TITLE
Use alpine for docker image base & pre-install bind-utils for debugging failures

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM scratch
+FROM alpine:3.3
 ADD mesos-dns_rootfs.tar.gz /
+RUN apk add -U bind-tools && rm -f /var/cache/apk/*
 EXPOSE 53
 CMD ["/usr/bin/mesos-dns"]


### PR DESCRIPTION
@lloesche What do you think about this? It includes a bunch of tools to make debugging easier (nsupdate, nslookup, host, dig, delv).
